### PR TITLE
Track HTTP response code

### DIFF
--- a/cmd_run.go
+++ b/cmd_run.go
@@ -208,7 +208,7 @@ func RunAction(c *cli.Context) error {
 				log.Infoln("Probing websites done!")
 				probeResults = nil
 			} else {
-				log.Infoln("Handling probe result")
+				log.WithField("url", pr.url).Infoln("Handling probe result")
 				if _, err := t.dbClient.SaveMeasurement(c, t.dbRun, pr); err != nil {
 					return fmt.Errorf("save measurement: %w", err)
 				}

--- a/db_client.go
+++ b/db_client.go
@@ -196,6 +196,11 @@ func (db *DBClient) SaveMeasurement(c *cli.Context, dbRun *models.Run, pr *probe
 		return nil, fmt.Errorf("getting metrics json")
 	}
 
+	bodyStr := ""
+	if pr.httpStatus != 0 && (pr.httpStatus < 200 || pr.httpStatus >= 300) {
+		bodyStr = pr.httpBody
+	}
+
 	m := &models.Measurement{
 		RunID:      dbRun.ID,
 		Website:    pr.website,
@@ -215,7 +220,7 @@ func (db *DBClient) SaveMeasurement(c *cli.Context, dbRun *models.Run, pr *probe
 		Metrics:    metrics,
 		Error:      pr.NullError(),
 		StatusCode: null.NewInt(pr.httpStatus, pr.httpStatus != 0),
-		Body:       null.NewString(pr.httpBody, pr.httpBody != ""),
+		Body:       null.NewString(bodyStr, bodyStr != ""),
 	}
 
 	if err := m.Insert(c.Context, db.handle, boil.Infer()); err != nil {

--- a/db_client.go
+++ b/db_client.go
@@ -214,6 +214,8 @@ func (db *DBClient) SaveMeasurement(c *cli.Context, dbRun *models.Run, pr *probe
 		CLSRating:  mapRating(pr.clsRating),
 		Metrics:    metrics,
 		Error:      pr.NullError(),
+		StatusCode: null.NewInt(pr.httpStatus, pr.httpStatus != 0),
+		Body:       null.NewString(pr.httpBody, pr.httpBody != ""),
 	}
 
 	if err := m.Insert(c.Context, db.handle, boil.Infer()); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     ports:
       - "4001:4001/tcp"
       - "4001:4001/udp"
-      - "127.0.0.1:5001:5001"
-      - "127.0.0.1:8080:8080"
+      - "0.0.0.0:5001:5001"
+      - "0.0.0.0:8080:8080"
   chrome:
     image: browserless/chrome:latest
     ports:
@@ -20,7 +20,7 @@ services:
   db:
     image: postgres:14
     ports:
-      - "5432:5432"
+      - "0.0.0.0:5432:5432"
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: tiros_test

--- a/migrations/000005_add_status_code_column.down.sql
+++ b/migrations/000005_add_status_code_column.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE measurements DROP COLUMN status_code;
+ALTER TABLE measurements DROP COLUMN body;
+
+COMMIT;

--- a/migrations/000005_add_status_code_column.up.sql
+++ b/migrations/000005_add_status_code_column.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE measurements ADD COLUMN status_code INT;
+ALTER TABLE measurements ADD COLUMN body TEXT;
+
+COMMIT;

--- a/models/measurements.go
+++ b/models/measurements.go
@@ -43,6 +43,8 @@ type Measurement struct {
 	TTFBRating null.String `boil:"ttfb_rating" json:"ttfb_rating,omitempty" toml:"ttfb_rating" yaml:"ttfb_rating,omitempty"`
 	FCPRating  null.String `boil:"fcp_rating" json:"fcp_rating,omitempty" toml:"fcp_rating" yaml:"fcp_rating,omitempty"`
 	LCPRating  null.String `boil:"lcp_rating" json:"lcp_rating,omitempty" toml:"lcp_rating" yaml:"lcp_rating,omitempty"`
+	StatusCode null.Int    `boil:"status_code" json:"status_code,omitempty" toml:"status_code" yaml:"status_code,omitempty"`
+	Body       null.String `boil:"body" json:"body,omitempty" toml:"body" yaml:"body,omitempty"`
 
 	R *measurementR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L measurementL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -68,6 +70,8 @@ var MeasurementColumns = struct {
 	TTFBRating string
 	FCPRating  string
 	LCPRating  string
+	StatusCode string
+	Body       string
 }{
 	ID:         "id",
 	RunID:      "run_id",
@@ -88,6 +92,8 @@ var MeasurementColumns = struct {
 	TTFBRating: "ttfb_rating",
 	FCPRating:  "fcp_rating",
 	LCPRating:  "lcp_rating",
+	StatusCode: "status_code",
+	Body:       "body",
 }
 
 var MeasurementTableColumns = struct {
@@ -110,6 +116,8 @@ var MeasurementTableColumns = struct {
 	TTFBRating string
 	FCPRating  string
 	LCPRating  string
+	StatusCode string
+	Body       string
 }{
 	ID:         "measurements.id",
 	RunID:      "measurements.run_id",
@@ -130,6 +138,8 @@ var MeasurementTableColumns = struct {
 	TTFBRating: "measurements.ttfb_rating",
 	FCPRating:  "measurements.fcp_rating",
 	LCPRating:  "measurements.lcp_rating",
+	StatusCode: "measurements.status_code",
+	Body:       "measurements.body",
 }
 
 // Generated where
@@ -286,6 +296,44 @@ func (w whereHelpertime_Time) GTE(x time.Time) qm.QueryMod {
 	return qmhelper.Where(w.field, qmhelper.GTE, x)
 }
 
+type whereHelpernull_Int struct{ field string }
+
+func (w whereHelpernull_Int) EQ(x null.Int) qm.QueryMod {
+	return qmhelper.WhereNullEQ(w.field, false, x)
+}
+func (w whereHelpernull_Int) NEQ(x null.Int) qm.QueryMod {
+	return qmhelper.WhereNullEQ(w.field, true, x)
+}
+func (w whereHelpernull_Int) LT(x null.Int) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LT, x)
+}
+func (w whereHelpernull_Int) LTE(x null.Int) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LTE, x)
+}
+func (w whereHelpernull_Int) GT(x null.Int) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GT, x)
+}
+func (w whereHelpernull_Int) GTE(x null.Int) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GTE, x)
+}
+func (w whereHelpernull_Int) IN(slice []int) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
+}
+func (w whereHelpernull_Int) NIN(slice []int) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
+}
+
+func (w whereHelpernull_Int) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
+func (w whereHelpernull_Int) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
+
 var MeasurementWhere = struct {
 	ID         whereHelperint
 	RunID      whereHelperint
@@ -306,6 +354,8 @@ var MeasurementWhere = struct {
 	TTFBRating whereHelpernull_String
 	FCPRating  whereHelpernull_String
 	LCPRating  whereHelpernull_String
+	StatusCode whereHelpernull_Int
+	Body       whereHelpernull_String
 }{
 	ID:         whereHelperint{field: "\"measurements\".\"id\""},
 	RunID:      whereHelperint{field: "\"measurements\".\"run_id\""},
@@ -326,6 +376,8 @@ var MeasurementWhere = struct {
 	TTFBRating: whereHelpernull_String{field: "\"measurements\".\"ttfb_rating\""},
 	FCPRating:  whereHelpernull_String{field: "\"measurements\".\"fcp_rating\""},
 	LCPRating:  whereHelpernull_String{field: "\"measurements\".\"lcp_rating\""},
+	StatusCode: whereHelpernull_Int{field: "\"measurements\".\"status_code\""},
+	Body:       whereHelpernull_String{field: "\"measurements\".\"body\""},
 }
 
 // MeasurementRels is where relationship names are stored.
@@ -356,9 +408,9 @@ func (r *measurementR) GetRun() *Run {
 type measurementL struct{}
 
 var (
-	measurementAllColumns            = []string{"id", "run_id", "website", "url", "type", "try", "ttfb", "fcp", "lcp", "metrics", "error", "created_at", "tti", "cls", "tti_rating", "cls_rating", "ttfb_rating", "fcp_rating", "lcp_rating"}
+	measurementAllColumns            = []string{"id", "run_id", "website", "url", "type", "try", "ttfb", "fcp", "lcp", "metrics", "error", "created_at", "tti", "cls", "tti_rating", "cls_rating", "ttfb_rating", "fcp_rating", "lcp_rating", "status_code", "body"}
 	measurementColumnsWithoutDefault = []string{"run_id", "website", "url", "type", "try", "created_at"}
-	measurementColumnsWithDefault    = []string{"id", "ttfb", "fcp", "lcp", "metrics", "error", "tti", "cls", "tti_rating", "cls_rating", "ttfb_rating", "fcp_rating", "lcp_rating"}
+	measurementColumnsWithDefault    = []string{"id", "ttfb", "fcp", "lcp", "metrics", "error", "tti", "cls", "tti_rating", "cls_rating", "ttfb_rating", "fcp_rating", "lcp_rating", "status_code", "body"}
 	measurementPrimaryKeyColumns     = []string{"id"}
 	measurementGeneratedColumns      = []string{"id"}
 )

--- a/models/providers.go
+++ b/models/providers.go
@@ -160,44 +160,6 @@ func (w whereHelpernull_Bool) GTE(x null.Bool) qm.QueryMod {
 func (w whereHelpernull_Bool) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
 func (w whereHelpernull_Bool) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
 
-type whereHelpernull_Int struct{ field string }
-
-func (w whereHelpernull_Int) EQ(x null.Int) qm.QueryMod {
-	return qmhelper.WhereNullEQ(w.field, false, x)
-}
-func (w whereHelpernull_Int) NEQ(x null.Int) qm.QueryMod {
-	return qmhelper.WhereNullEQ(w.field, true, x)
-}
-func (w whereHelpernull_Int) LT(x null.Int) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.LT, x)
-}
-func (w whereHelpernull_Int) LTE(x null.Int) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.LTE, x)
-}
-func (w whereHelpernull_Int) GT(x null.Int) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.GT, x)
-}
-func (w whereHelpernull_Int) GTE(x null.Int) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.GTE, x)
-}
-func (w whereHelpernull_Int) IN(slice []int) qm.QueryMod {
-	values := make([]interface{}, 0, len(slice))
-	for _, value := range slice {
-		values = append(values, value)
-	}
-	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
-}
-func (w whereHelpernull_Int) NIN(slice []int) qm.QueryMod {
-	values := make([]interface{}, 0, len(slice))
-	for _, value := range slice {
-		values = append(values, value)
-	}
-	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
-}
-
-func (w whereHelpernull_Int) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
-func (w whereHelpernull_Int) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
-
 var ProviderWhere = struct {
 	ID             whereHelperint
 	RunID          whereHelperint

--- a/probe.go
+++ b/probe.go
@@ -56,27 +56,9 @@ type probeResult struct {
 }
 
 func (pr *probeResult) NullError() null.String {
-	if pr.httpStatus != 0 && (pr.httpStatus < 200 || pr.httpStatus >= 300) {
-		// Loading the website yielded an HTTP error
-
-		errStr := fmt.Sprintf("http error %d", pr.httpStatus)
-
-		// If we got a 500er error code via Kubo, also attach the body as
-		// it could give us insights in what was going wrong.
-		if pr.mType == models.MeasurementTypeKUBO && (pr.httpStatus >= 500 || pr.httpStatus < 600) {
-			errStr = fmt.Sprintf("%s: %s", errStr, pr.httpBody)
-		}
-
-		// Carry all other errors as well
-		if pr.err != nil {
-			errStr = fmt.Sprintf("%s: %s", pr.err.Error(), errStr)
-		}
-
-		return null.StringFrom(errStr)
-	} else if pr.err != nil {
+	if pr.err != nil {
 		return null.StringFrom(pr.err.Error())
 	}
-
 	return null.NewString("", false)
 }
 

--- a/providers.go
+++ b/providers.go
@@ -114,6 +114,7 @@ func (t *tiros) findProviders(ctx context.Context, website string, results chan<
 		if err = dec.Decode(&evt); err != nil {
 			return fmt.Errorf("decode routing/findprovs response: %w", err)
 		}
+
 		if evt.Type != routing.Provider {
 			continue
 		}


### PR DESCRIPTION
**Changelog**

We found that if there's a DNSLink error, the error page is displayed. We're then measuring the performance of this error page.

<img width="758" alt="Screenshot 2023-06-22 at 13 26 55" src="https://github.com/plprobelab/tiros/assets/11836793/2b2808be-d7f2-48e6-a012-ed604e71c397">

This error page has great performance 👍 because the TTFB just measures the _faulty_ DNS lookup.

Now, we're also keeping track of the HTTP status code of the website request. In the above scenario the response code is 500 which we can then easily filter out in our measurements.

**Missing**

- [ ] save response status code in a structured manner (aka create a migration that adds a dedicated status code column 👍 )