### PR TITLE
feat: add global timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REPO_SERVER=019120760881.dkr.ecr.us-east-1.amazonaws.com
 
 docker:
 	$(eval GIT_TAG := $(shell git rev-parse --short HEAD))
-	docker build -t "${REPO_SERVER}/probelab:tiros-${GIT_TAG}" .
+	docker build --platform linux/amd64 -t "${REPO_SERVER}/probelab:tiros-${GIT_TAG}" .
 
 docker-push: docker
 	docker push "${REPO_SERVER}/probelab:tiros-${GIT_TAG}"

--- a/cmd_run.go
+++ b/cmd_run.go
@@ -131,6 +131,12 @@ var RunCommand = &cli.Command{
 			EnvVars: []string{"TIROS_IPFS_IMPLEMENTATION"},
 			Value:   "KUBO",
 		},
+		&cli.DurationFlag{
+			Name:    "timeout",
+			Usage:   "The maximum allowed time for this experiment to run (0 no timeout)",
+			EnvVars: []string{"TIROS_RUN_TIMEOUT"},
+			Value:   time.Duration(0),
+		},
 	},
 	Action: RunAction,
 }
@@ -146,6 +152,14 @@ type tiros struct {
 func RunAction(c *cli.Context) error {
 	log.Infoln("Starting Tiros run...")
 	defer log.Infoln("Stopped Tiros run.")
+
+	// create global timeout context
+	timeout := c.Duration("timeout")
+	if timeout > 0 {
+		ctx, cancel := context.WithTimeout(c.Context, timeout)
+		defer cancel()
+		c.Context = ctx
+	}
 
 	// Initialize database client
 	var err error


### PR DESCRIPTION
ECS tasks cannot be configured with a global timeout. This means tasks could potentially run forever. This PR cancels the global context when a timeout is configured

cc @sgtpooki